### PR TITLE
docs: fix typo on the docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,9 +19,7 @@ Below you will only find the technical reference automatically generated from th
 == Technical Reference
 
 // BEGIN_TF_DOCS
-=== Requirements
 
-No requirements.
 
 === Providers
 
@@ -34,10 +32,6 @@ The following providers are used by this module:
 - [[provider_random]] <<provider_random,random>>
 
 - [[provider_utils]] <<provider_utils,utils>>
-
-=== Modules
-
-No modules.
 
 === Resources
 
@@ -138,7 +132,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0-alpha.8"`
 
 ==== [[input_thanos]] <<input_thanos,thanos>>
 
@@ -265,7 +259,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0-alpha.8"`
 |no
 
 |[[input_thanos]] <<input_thanos,thanos>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -206,13 +206,7 @@ This value MUST be configured otherwise the compactor will NOT work on a product
 This module must be one of the first ones to be deployed and consequently it needs to be deployed after the module `argocd_bootstrap`.
 
 // BEGIN_TF_DOCS
-=== Requirements
 
-No requirements.
-
-=== Providers
-
-No providers.
 
 === Modules
 
@@ -223,10 +217,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -330,7 +320,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0-alpha.8"`
 
 ==== [[input_thanos]] <<input_thanos,thanos>>
 
@@ -457,7 +447,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0-alpha.8"`
 |no
 
 |[[input_thanos]] <<input_thanos,thanos>>

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,6 +2,6 @@
 * Module Variants
 ** xref:ROOT:aks/README.adoc[AKS]
 ** xref:ROOT:eks/README.adoc[EKS]
-** xref:ROOT:find/README.adoc[KinD]
+** xref:ROOT:kind/README.adoc[KinD]
 * https://github.com/camptocamp/devops-stack-module-thanos[Repository,window=_blank]
 * xref:ROOT:ROOT:index.adoc[_Return to DevOps Stack docs_]

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -258,13 +258,7 @@ This value MUST be configured otherwise the compactor will NOT work on a product
 This module must be one of the first ones to be deployed and consequently it needs to be deployed after the module `argocd_bootstrap`.
 
 // BEGIN_TF_DOCS
-=== Requirements
 
-No requirements.
-
-=== Providers
-
-No providers.
 
 === Modules
 
@@ -275,10 +269,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -382,7 +372,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0-alpha.8"`
 
 ==== [[input_thanos]] <<input_thanos,thanos>>
 
@@ -509,7 +499,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0-alpha.8"`
 |no
 
 |[[input_thanos]] <<input_thanos,thanos>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -155,13 +155,7 @@ This module needs an OIDC provider to function and consequently it must be one d
 This module needs to have the configuration for the S3 bucket and consequently it must be one deployed after the module `minio`.
 
 // BEGIN_TF_DOCS
-=== Requirements
 
-No requirements.
-
-=== Providers
-
-No providers.
 
 === Modules
 
@@ -172,10 +166,6 @@ The following Modules are called:
 Source: ../
 
 Version:
-
-=== Resources
-
-No resources.
 
 === Required Inputs
 
@@ -280,7 +270,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v1.0.0-alpha.7"`
+Default: `"v1.0.0-alpha.8"`
 
 ==== [[input_thanos]] <<input_thanos,thanos>>
 
@@ -408,7 +398,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v1.0.0-alpha.7"`
+|`"v1.0.0-alpha.8"`
 |no
 
 |[[input_thanos]] <<input_thanos,thanos>>


### PR DESCRIPTION
This is a typo I found while working on the general documentation. No need to generate a release, we will let this be integrated into another modification later.