### PR TITLE
feat(azure)!: use managed identity to access object storage

### DIFF
--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -257,7 +257,7 @@ Type: `string`
 
 ==== [[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 
-Description: Azure metrics storage configuration
+Description: Azure Blob Storage configuration for metric archival.
 
 Type:
 [source,hcl]
@@ -458,7 +458,7 @@ object({
 |no
 
 |[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
-|Azure metrics storage configuration
+|Azure Blob Storage configuration for metric archival.
 |
 
 [source]

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -208,6 +208,12 @@ This module must be one of the first ones to be deployed and consequently it nee
 // BEGIN_TF_DOCS
 
 
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_azurerm]] <<provider_azurerm,azurerm>>
+
 === Modules
 
 The following Modules are called:
@@ -217,6 +223,15 @@ The following Modules are called:
 Source: ../
 
 Version:
+
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.thanos] (resource)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] (data source)
+- https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] (data source)
 
 === Required Inputs
 
@@ -242,15 +257,16 @@ Type: `string`
 
 ==== [[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 
-Description: Azure Blob Storage configuration values for the storage container where the archived metrics will be stored.
+Description: Azure metrics storage configuration
 
 Type:
 [source,hcl]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container       = string
+    storage_account = string
+    managed_identity_node_rg_name = optional(string, null)
+    storage_account_key = optional(string, null)
   })
 ----
 
@@ -347,12 +363,31 @@ Description: ID to pass other modules in order to refer to this module as a depe
 // BEGIN_TF_TABLES
 
 
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_azurerm]] <<provider_azurerm,azurerm>> |n/a
+|===
+
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
 |[[module_thanos]] <<module_thanos,thanos>> |../ |
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment[azurerm_role_assignment.contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.thanos] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group[azurerm_resource_group.node] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container[azurerm_storage_container.container] |data source
 |===
 
 = Inputs
@@ -423,15 +458,16 @@ object({
 |no
 
 |[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
-|Azure Blob Storage configuration values for the storage container where the archived metrics will be stored.
+|Azure metrics storage configuration
 |
 
 [source]
 ----
 object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container       = string
+    storage_account = string
+    managed_identity_node_rg_name = optional(string, null)
+    storage_account_key = optional(string, null)
   })
 ----
 

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -3,20 +3,12 @@ variable "metrics_storage" {
   type = object({
     container       = string
     storage_account = string
-    use_managed_identity = object({
-      enabled      = bool
-      node_rg_name = optional(string, null)
-    })
+    managed_identity_node_rg_name = optional(string, null)
     storage_account_key = optional(string, null)
   })
 
   validation {
-    condition     = var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.storage_account_key == null)
-    error_message = "Setting storage_account_key and using a managed identity are mutually exclusive."
-  }
-
-  validation {
-    condition     = var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.use_managed_identity.node_rg_name != null)
-    error_message = "use_managed_identity.node_rg_name must only be set when using a managed identity."
+    condition     = (var.metrics_storage.managed_identity_node_rg_name == null) != (var.metrics_storage.storage_account_key == null)
+    error_message = "You must set one (and only one) of these attributes: managed_identity_node_rg_name, storage_account_key."
   }
 }

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,8 +1,22 @@
 variable "metrics_storage" {
-  description = "Azure Blob Storage configuration values for the storage container where the archived metrics will be stored."
+  description = "Azure metrics storage configuration"
   type = object({
-    container           = string
-    storage_account     = string
-    storage_account_key = string
+    container       = string
+    storage_account = string
+    use_managed_identity = object({
+      enabled      = bool
+      node_rg_name = optional(string, null)
+    })
+    storage_account_key = optional(string, null)
   })
+
+  validation {
+    condition     = var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.storage_account_key == null)
+    error_message = "Setting storage_account_key and using a managed identity are mutually exclusive."
+  }
+
+  validation {
+    condition     = var.metrics_storage.use_managed_identity.enabled == (var.metrics_storage.use_managed_identity.node_rg_name != null)
+    error_message = "use_managed_identity.node_rg_name must only be set when using a managed identity."
+  }
 }

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -1,5 +1,5 @@
 variable "metrics_storage" {
-  description = "Azure metrics storage configuration"
+  description = "Azure Blob Storage configuration for metric archival."
   type = object({
     container       = string
     storage_account = string

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,14 +1,25 @@
 locals {
   helm_values = [{
-    thanos = {
+    # TODO check possible single merge call
+    thanos = merge(var.metrics_storage.use_managed_identity.enabled ? {
+      commonLabels = {
+        aadpodidbinding = "thanos"
+      }
+      } : null, {
       objstoreConfig = {
         type = "AZURE"
-        config = {
-          container           = "${var.metrics_storage.container}"
-          storage_account     = "${var.metrics_storage.storage_account}"
-          storage_account_key = "${var.metrics_storage.storage_account_key}"
-        }
+        config = merge({
+          container       = var.metrics_storage.container
+          storage_account = var.metrics_storage.storage_account
+          }, var.metrics_storage.use_managed_identity.enabled ? null : {
+          storage_account_key = var.metrics_storage.storage_account_key
+        })
       }
+    })
+    }, var.metrics_storage.use_managed_identity.enabled ? {
+    azureIdentity = {
+      resourceID = azurerm_user_assigned_identity.thanos[0].id
+      clientID   = azurerm_user_assigned_identity.thanos[0].client_id
     }
-  }]
+  } : null]
 }

--- a/aks/locals.tf
+++ b/aks/locals.tf
@@ -1,7 +1,9 @@
 locals {
+  use_managed_identity = var.metrics_storage.managed_identity_node_rg_name != null
+
   helm_values = [{
     # TODO check possible single merge call
-    thanos = merge(var.metrics_storage.use_managed_identity.enabled ? {
+    thanos = merge(local.use_managed_identity ? {
       commonLabels = {
         aadpodidbinding = "thanos"
       }
@@ -11,12 +13,12 @@ locals {
         config = merge({
           container       = var.metrics_storage.container
           storage_account = var.metrics_storage.storage_account
-          }, var.metrics_storage.use_managed_identity.enabled ? null : {
+          }, local.use_managed_identity ? null : {
           storage_account_key = var.metrics_storage.storage_account_key
         })
       }
     })
-    }, var.metrics_storage.use_managed_identity.enabled ? {
+    }, local.use_managed_identity ? {
     azureIdentity = {
       resourceID = azurerm_user_assigned_identity.thanos[0].id
       clientID   = azurerm_user_assigned_identity.thanos[0].client_id

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,18 +1,18 @@
 data "azurerm_resource_group" "node" {
-  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+  count = local.use_managed_identity ? 1 : 0
 
-  name = var.metrics_storage.use_managed_identity.node_rg_name
+  name = var.metrics_storage.managed_identity_node_rg_name
 }
 
 data "azurerm_storage_container" "container" {
-  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+  count = local.use_managed_identity ? 1 : 0
 
   name                 = var.metrics_storage.container
   storage_account_name = var.metrics_storage.storage_account
 }
 
 resource "azurerm_user_assigned_identity" "thanos" {
-  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+  count = local.use_managed_identity ? 1 : 0
 
   resource_group_name = data.azurerm_resource_group.node[0].name
   location            = data.azurerm_resource_group.node[0].location
@@ -20,7 +20,7 @@ resource "azurerm_user_assigned_identity" "thanos" {
 }
 
 resource "azurerm_role_assignment" "contributor" {
-  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+  count = local.use_managed_identity ? 1 : 0
 
   scope                = data.azurerm_storage_container.container[0].resource_manager_id
   role_definition_name = "Storage Blob Data Contributor"

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -1,3 +1,32 @@
+data "azurerm_resource_group" "node" {
+  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+
+  name = var.metrics_storage.use_managed_identity.node_rg_name
+}
+
+data "azurerm_storage_container" "container" {
+  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+
+  name                 = var.metrics_storage.container
+  storage_account_name = var.metrics_storage.storage_account
+}
+
+resource "azurerm_user_assigned_identity" "thanos" {
+  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+
+  resource_group_name = data.azurerm_resource_group.node[0].name
+  location            = data.azurerm_resource_group.node[0].location
+  name                = "thanos"
+}
+
+resource "azurerm_role_assignment" "contributor" {
+  count = var.metrics_storage.use_managed_identity.enabled ? 1 : 0
+
+  scope                = data.azurerm_storage_container.container[0].resource_manager_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.thanos[0].principal_id
+}
+
 module "thanos" {
   source = "../"
 

--- a/charts/thanos/templates/azureidentity.yaml
+++ b/charts/thanos/templates/azureidentity.yaml
@@ -1,0 +1,11 @@
+{{- with .Values.azureIdentity }}
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: thanos
+spec:
+  type: 0
+  resourceID: {{ .resourceID }}
+  clientID: {{ .clientID }}
+{{- end }}

--- a/charts/thanos/templates/azureidentitybinding.yaml
+++ b/charts/thanos/templates/azureidentitybinding.yaml
@@ -1,0 +1,10 @@
+{{- with .Values.azureIdentity }}
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: thanos-binding
+spec:
+  azureIdentity: thanos
+  selector: thanos
+{{- end }}


### PR DESCRIPTION
## Description of the changes
User can now choose between key-based and identity-based access to object storage.
The variable `metrics_storage` is refactored as follow:
```hcl
metrics_storage = {
  container       = azurerm_storage_container.metrics.name
  storage_account = azurerm_storage_account.metrics.name

  managed_identity_node_rg_name = module.cluster.node_resource_group # Unset when using account key.

  storage_account_key = azurerm_storage_account.metrics.primary_access_key # Unset when using a managed identity
}
```
**Imporant:** when using identity-based access, aad-pod-identity must be declared as module dependency.

## Breaking change

- [ ] No
- [ ] Yes (in the Helm chart(s))
- [x] Yes (in the module itself): see new variable for setting storage parameters above.

## Tests executed on which distribution(s)

- [ ] KinD
- [x] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [ ] SKS (Exoscale)
