### PR TITLE
fix: add default argocd_namespace

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,15 +70,17 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -183,10 +185,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -222,8 +224,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -274,15 +274,17 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -446,8 +448,8 @@ object({
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -310,15 +310,17 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -462,8 +464,8 @@ object({
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -208,15 +208,17 @@ Description: Base domain of the cluster. Value used for the ingress' URL of the 
 
 Type: `string`
 
+=== Optional Inputs
+
+The following input variables are optional (have default values):
+
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
 Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
-=== Optional Inputs
-
-The following input variables are optional (have default values):
+Default: `"argocd"`
 
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
@@ -361,8 +363,8 @@ object({
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
-|n/a
-|yes
+|`"argocd"`
+|no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,7 @@ variable "base_domain" {
 variable "argocd_namespace" {
   description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
   type        = string
+  default     = "argocd"
 }
 
 variable "target_revision" {


### PR DESCRIPTION
## Description of the changes

Just a small fix to add the default Argo CD namespace.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
