### PR TITLE
feat: add variables to set AppProject, labels and destination cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,11 +38,11 @@ The following providers are used by this module:
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 === Resources
 
@@ -113,7 +113,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v2.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -218,10 +218,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -281,7 +281,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v2.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -194,10 +218,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
-|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -234,6 +258,24 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -283,6 +283,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -454,6 +478,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -313,7 +313,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v2.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -501,7 +501,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v2.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -33,6 +33,8 @@ module "thanos" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -34,6 +34,7 @@ module "thanos" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -281,6 +281,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -432,6 +456,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -311,7 +311,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v2.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -479,7 +479,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v2.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -5,6 +5,7 @@ module "thanos" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -4,6 +4,8 @@ module "thanos" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -215,6 +215,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -368,6 +392,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -245,7 +245,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v2.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -415,7 +415,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v2.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -5,6 +5,7 @@ module "thanos" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -4,6 +4,8 @@ module "thanos" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  oauth2_proxy_image = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
+
   # values.yaml translated into HCL structures.
   # Possible values available here -> https://github.com/bitnami/charts/tree/master/bitnami/thanos/
   helm_values = [{
@@ -57,7 +59,7 @@ locals {
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.bucketweb_domain}/oauth2/callback",
           ], local.thanos.oidc.oauth2_proxy_extra_args)
-          image = "quay.io/oauth2-proxy/oauth2-proxy:v7.1.3"
+          image = local.oauth2_proxy_image
           name  = "thanos-proxy"
           ports = [{
             containerPort = 9075
@@ -148,7 +150,7 @@ locals {
             "--email-domain=*",
             "--redirect-url=https://${local.thanos.query_domain}/oauth2/callback",
           ], local.thanos.oidc.oauth2_proxy_extra_args)
-          image = "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+          image = local.oauth2_proxy_image
           name  = "thanos-proxy"
           ports = [{
             containerPort = 9075

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,10 @@ resource "argocd_application" "this" {
   metadata {
     name      = var.destination_cluster != "in-cluster" ? "thanos-${var.destination_cluster}" : "thanos"
     namespace = var.argocd_namespace
+    labels = merge({
+      "application" = "thanos"
+      "cluster"     = var.destination_cluster
+    }, var.argocd_labels)
   }
 
   timeouts {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -194,7 +194,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.4.0"`
+Default: `"v2.5.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -369,7 +369,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.4.0"`
+|`"v2.5.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -164,6 +164,30 @@ Type: `string`
 
 Default: `"argocd"`
 
+==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
+
+Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+
+Type: `string`
+
+Default: `null`
+
+==== [[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+
+Description: Labels to attach to the Argo CD Application resource.
+
+Type: `map(string)`
+
+Default: `{}`
+
+==== [[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+
+Description: Destination cluster where the application should be deployed.
+
+Type: `string`
+
+Default: `"in-cluster"`
+
 ==== [[input_target_revision]] <<input_target_revision,target_revision>>
 
 Description: Override of target revision of the application chart.
@@ -322,6 +346,24 @@ object({
 |Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |`"argocd"`
+|no
+
+|[[input_argocd_project]] <<input_argocd_project,argocd_project>>
+|Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
+|`string`
+|`null`
+|no
+
+|[[input_argocd_labels]] <<input_argocd_labels,argocd_labels>>
+|Labels to attach to the Argo CD Application resource.
+|`map(string)`
+|`{}`
+|no
+
+|[[input_destination_cluster]] <<input_destination_cluster,destination_cluster>>
+|Destination cluster where the application should be deployed.
+|`string`
+|`"in-cluster"`
 |no
 
 |[[input_target_revision]] <<input_target_revision,target_revision>>

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -5,6 +5,7 @@ module "thanos" {
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
   argocd_project         = var.argocd_project
+  argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -4,6 +4,8 @@ module "thanos" {
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
   argocd_namespace       = var.argocd_namespace
+  argocd_project         = var.argocd_project
+  destination_cluster    = var.destination_cluster
   target_revision        = var.target_revision
   cluster_issuer         = var.cluster_issuer
   namespace              = var.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,18 @@ variable "argocd_namespace" {
   default     = "argocd"
 }
 
+variable "argocd_project" {
+  description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
+  type        = string
+  default     = null
+}
+
+variable "destination_cluster" {
+  description = "Destination cluster where the application should be deployed."
+  type        = string
+  default     = "in-cluster"
+}
+
 variable "target_revision" {
   description = "Override of target revision of the application chart."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "argocd_project" {
   default     = null
 }
 
+variable "argocd_labels" {
+  description = "Labels to attach to the Argo CD Application resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "destination_cluster" {
   description = "Destination cluster where the application should be deployed."
   type        = string


### PR DESCRIPTION
## Description of the changes

This PR:
- Adds the required variables and configuration to allow the module to be deployed on a different cluster than Argo CD.
- Adds the possibility of placing the application inside a specified Argo CD project in order to avoid having a single project for each application throughout multiple clusters.
- Adds labels and a variable to add more labels to the Argo CD application to make it easier to sort applications on the web interface of Argo CD.
- Adds local to set the image of OAuth2-Proxy and updates said image to v7.5.0.

**All these changes are made in preparation for having a centralized Argo CD that controls applications throughout multiple clusters.**

:warning: **Do a _Rebase and merge_.**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] EKS (AWS)
- [x] SKS (Exoscale)