### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,9 +40,9 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -36,13 +36,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -76,6 +76,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -106,7 +114,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -256,6 +264,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -277,7 +291,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -227,10 +227,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/README.adoc
+++ b/README.adoc
@@ -36,13 +36,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_null]] <<provider_null,null>> (>= 3)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -78,7 +78,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -265,7 +265,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -282,7 +282,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -492,7 +492,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -280,6 +280,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -310,7 +318,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -483,6 +491,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -504,7 +518,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -61,6 +61,7 @@ module "thanos" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -273,6 +273,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -303,7 +311,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -452,6 +460,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -473,7 +487,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -275,7 +275,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -461,7 +461,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -3,6 +3,7 @@ module "thanos" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -209,7 +209,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -397,7 +397,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -207,6 +207,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -237,7 +245,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -388,6 +396,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -409,7 +423,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -3,6 +3,7 @@ module "thanos" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/locals.tf
+++ b/locals.tf
@@ -73,7 +73,7 @@ locals {
         resources              = local.thanos.compactor_resources
         persistence = {
           # The Access Mode needs to be set as ReadWriteOnce because AWS Elastic Block storage does not support other
-          # modes (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).          
+          # modes (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).
           # Since the compactor is the only pod accessing this volume, there should be no issue to have this as
           # ReadWriteOnce (https://stackoverflow.com/a/57799347).
           accessModes = [
@@ -127,7 +127,7 @@ locals {
           hostname = ""
           extraRules = [
             {
-              host = "thanos-bucketweb.apps.${var.base_domain}"
+              host = "thanos-bucketweb.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
               http = {
                 paths = [
                   {
@@ -168,7 +168,7 @@ locals {
           extraTls = [{
             secretName = "thanos-bucketweb-tls"
             hosts = [
-              "thanos-bucketweb.apps.${var.base_domain}",
+              "thanos-bucketweb.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               "${local.thanos.bucketweb_domain}"
             ]
           }]
@@ -261,7 +261,7 @@ locals {
           hostname = ""
           extraRules = [
             {
-              host = "thanos-query.apps.${var.base_domain}"
+              host = "thanos-query.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
               http = {
                 paths = [
                   {
@@ -302,7 +302,7 @@ locals {
           extraTls = [{
             secretName = "thanos-query-tls"
             hosts = [
-              "thanos-query.apps.${var.base_domain}",
+              "thanos-query.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}",
               "${local.thanos.query_domain}"
             ]
           }]
@@ -316,8 +316,8 @@ locals {
   }]
 
   thanos_defaults = {
-    query_domain     = "thanos-query.apps.${var.cluster_name}.${var.base_domain}"
-    bucketweb_domain = "thanos-bucketweb.apps.${var.cluster_name}.${var.base_domain}"
+    query_domain     = "thanos-query.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
+    bucketweb_domain = "thanos-bucketweb.${trimprefix("${var.subdomain}.${var.cluster_name}", ".")}.${var.base_domain}"
 
     # TODO Create proper Terraform variables for these values instead of bundling everything inside of these locals
 

--- a/locals.tf
+++ b/locals.tf
@@ -118,7 +118,6 @@ locals {
           annotations = {
             "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
             "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.middlewares" = "traefik-withclustername@kubernetescrd"
             "traefik.ingress.kubernetes.io/router.tls"         = "true"
             "ingress.kubernetes.io/ssl-redirect"               = "true"
             "kubernetes.io/ingress.allow-http"                 = "false"

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -156,6 +156,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_argocd_project]] <<input_argocd_project,argocd_project>>
 
 Description: Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
@@ -186,7 +194,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.1.0"`
+Default: `"v3.2.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -342,6 +350,12 @@ object({
 |n/a
 |yes
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_argocd_project]] <<input_argocd_project,argocd_project>>
 |Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application.
 |`string`
@@ -363,7 +377,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.1.0"`
+|`"v3.2.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -158,7 +158,7 @@ The following input variables are optional (have default values):
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -351,7 +351,7 @@ object({
 |yes
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -3,6 +3,7 @@ module "thanos" {
 
   cluster_name           = var.cluster_name
   base_domain            = var.base_domain
+  subdomain              = var.subdomain
   argocd_project         = var.argocd_project
   argocd_labels          = var.argocd_labels
   destination_cluster    = var.destination_cluster

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "argocd_project" {
   description = "Name of the Argo CD AppProject where the Application should be created. If not set, the Application will be created in a new AppProject only for this Application."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,7 @@ variable "subdomain" {
   description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "argocd_project" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "base_domain" {
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
 }


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [x] KinD
- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)