### PR TITLE
fix: remove variable for the Grafana dashboard and remove legacy ingress annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,13 +36,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -114,7 +114,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -182,19 +182,11 @@ Default: `{}`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
-Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 
 Type: `bool`
 
 Default: `false`
-
-==== [[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-
-Description: Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-
-Type: `bool`
-
-Default: `true`
 
 === Outputs
 
@@ -291,7 +283,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -351,15 +343,9 @@ object({
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
-|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 |`bool`
 |`false`
-|no
-
-|[[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-|Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-|`bool`
-|`true`
 |no
 
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -318,7 +318,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -386,19 +386,11 @@ Default: `{}`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
-Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 
 Type: `bool`
 
 Default: `false`
-
-==== [[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-
-Description: Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-
-Type: `bool`
-
-Default: `true`
 
 === Outputs
 
@@ -518,7 +510,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -578,15 +570,9 @@ object({
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
-|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 |`bool`
 |`false`
-|no
-
-|[[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-|Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-|`bool`
-|`true`
 |no
 
 |===

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -72,8 +72,7 @@ module "thanos" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
-  thanos                      = var.thanos
-  enable_monitoring_dashboard = var.enable_monitoring_dashboard
+  thanos = var.thanos
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/charts/thanos/templates/grafana-dashboard.yaml
+++ b/charts/thanos/templates/grafana-dashboard.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.grafana_dashboard.enabled }}
+{{- if $.Values.thanos.metrics.serviceMonitor.enabled }}
 {{- $files := .Files.Glob "dashboards/*.json" }}
 {{- if $files }}
 apiVersion: v1

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -311,7 +311,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -379,19 +379,11 @@ Default: `{}`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
-Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 
 Type: `bool`
 
 Default: `false`
-
-==== [[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-
-Description: Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-
-Type: `bool`
-
-Default: `true`
 
 === Outputs
 
@@ -487,7 +479,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -547,15 +539,9 @@ object({
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
-|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 |`bool`
 |`false`
-|no
-
-|[[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-|Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-|`bool`
-|`true`
 |no
 
 |===

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -14,8 +14,7 @@ module "thanos" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
-  thanos                      = var.thanos
-  enable_monitoring_dashboard = var.enable_monitoring_dashboard
+  thanos = var.thanos
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -245,7 +245,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -313,19 +313,11 @@ Default: `{}`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
-Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 
 Type: `bool`
 
 Default: `false`
-
-==== [[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-
-Description: Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-
-Type: `bool`
-
-Default: `true`
 
 === Outputs
 
@@ -423,7 +415,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -483,15 +475,9 @@ object({
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
-|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 |`bool`
 |`false`
-|no
-
-|[[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-|Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-|`bool`
-|`true`
 |no
 
 |===

--- a/kind/main.tf
+++ b/kind/main.tf
@@ -14,8 +14,7 @@ module "thanos" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
-  thanos                      = var.thanos
-  enable_monitoring_dashboard = var.enable_monitoring_dashboard
+  thanos = var.thanos
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,12 @@
 locals {
   oauth2_proxy_image = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
 
+  ingress_annotations = {
+    "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
+    "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
+    "traefik.ingress.kubernetes.io/router.tls"         = "true"
+  }
+
   # values.yaml translated into HCL structures.
   # Possible values available here -> https://github.com/bitnami/charts/tree/master/bitnami/thanos/
   helm_values = [{
@@ -114,16 +120,10 @@ locals {
           }]
         }
         ingress = {
-          enabled = true
-          annotations = {
-            "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-            "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.tls"         = "true"
-            "ingress.kubernetes.io/ssl-redirect"               = "true"
-            "kubernetes.io/ingress.allow-http"                 = "false"
-          }
-          tls      = false
-          hostname = ""
+          enabled     = true
+          annotations = local.ingress_annotations
+          tls         = false
+          hostname    = ""
           extraRules = [
             {
               host = "thanos-bucketweb.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"
@@ -247,17 +247,10 @@ locals {
           }]
         }
         ingress = {
-          enabled = true
-          annotations = {
-            "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-            "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.middlewares" = "traefik-withclustername@kubernetescrd"
-            "traefik.ingress.kubernetes.io/router.tls"         = "true"
-            "ingress.kubernetes.io/ssl-redirect"               = "true"
-            "kubernetes.io/ingress.allow-http"                 = "false"
-          }
-          tls      = false
-          hostname = ""
+          enabled     = true
+          annotations = local.ingress_annotations
+          tls         = false
+          hostname    = ""
           extraRules = [
             {
               host = "thanos-query.${trimprefix("${var.subdomain}.${var.base_domain}", ".")}"

--- a/locals.tf
+++ b/locals.tf
@@ -302,9 +302,6 @@ locals {
       }
 
     }
-    grafana_dashboard = {
-      enabled = var.enable_monitoring_dashboard
-    }
   }]
 
   thanos_defaults = {

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -194,7 +194,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.3.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -262,19 +262,11 @@ Default: `{}`
 
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
-Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 
 Type: `bool`
 
 Default: `false`
-
-==== [[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-
-Description: Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-
-Type: `bool`
-
-Default: `true`
 
 === Outputs
 
@@ -377,7 +369,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.3.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -437,15 +429,9 @@ object({
 |no
 
 |[[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
-|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
+|Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
 |`bool`
 |`false`
-|no
-
-|[[input_enable_monitoring_dashboard]] <<input_enable_monitoring_dashboard,enable_monitoring_dashboard>>
-|Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`.
-|`bool`
-|`true`
 |no
 
 |===

--- a/sks/main.tf
+++ b/sks/main.tf
@@ -14,8 +14,7 @@ module "thanos" {
   app_autosync           = var.app_autosync
   dependency_ids         = var.dependency_ids
 
-  thanos                      = var.thanos
-  enable_monitoring_dashboard = var.enable_monitoring_dashboard
+  thanos = var.thanos
 
   helm_values = concat(local.helm_values, var.helm_values)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,13 +92,7 @@ variable "thanos" {
 }
 
 variable "enable_service_monitor" {
-  description = "Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here]."
+  description = "Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here]."
   type        = bool
   default     = false
-}
-
-variable "enable_monitoring_dashboard" {
-  description = "Boolean to enable the provisioning of multiple Grafana dashboards, one for each component of Thanos. These dashboards are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/tree/main/examples/dashboards[here]. Requires the variable `enable_service_monitor` to be set to `true`."
-  type        = bool
-  default     = true
 }


### PR DESCRIPTION
## Description of the changes

The purpose of this PR is mainly to remove old SSL annotations that are no longer useful. The SSL redirection is no longer defined by these annotations, I think this is a leftover from ancient code. The HTTP -> HTTPS redirection is handled natively by the Traefik module and is enabled by default (a variable is available to deactivate it if necessary).

In parallel, I've decided to remove the `enable_monitoring_dashboard`, because on the other modules we've decided to simply deploy the dashboards automatically as long as the serviceMonitor for the metrics is activated. I think this approach is simpler, so I made this removal.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes: the removal of the `enable_monitoring_dashboard` variable

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)
