### PR TITLE
feat(eks)!: add option to create IAM role for the metrics storage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,13 +36,13 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_null]] <<provider_null,null>> (>= 3)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>> (>= 3)
 
 === Resources
 
@@ -114,7 +114,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -301,10 +301,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
+|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources
@@ -365,7 +365,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 
 A https://devops-stack.io[DevOps Stack] module to deploy and configure https://thanos.io[Thanos].
 
-The Thanos chart used by this module is shipped in this repository as well, in order to avoid any unwanted behaviors caused by unsupported versions. 
+The Thanos chart used by this module is shipped in this repository as well, in order to avoid any unwanted behaviors caused by unsupported versions.
 
 [cols="1,1,1",options="autowidth,header"]
 |===

--- a/aks/README.adoc
+++ b/aks/README.adoc
@@ -318,7 +318,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -592,7 +592,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/aks/extra-variables.tf
+++ b/aks/extra-variables.tf
@@ -10,10 +10,10 @@ variable "metrics_storage" {
 
   validation {
     condition     = (var.metrics_storage.managed_identity_node_rg_name == null && var.metrics_storage.managed_identity_oidc_issuer_url == null) != (var.metrics_storage.storage_account_key == null)
-    error_message = "You can either set the variables for the managed identity or use storage account key, not both at the same time."
+    error_message = "You can either set the variables for the managed identity or use a storage account key, not both at the same time."
   }
 
-    validation {
+  validation {
     condition     = (var.metrics_storage.managed_identity_node_rg_name == null) == (var.metrics_storage.managed_identity_oidc_issuer_url == null)
     error_message = "When using the managed identity, both `managed_identity_node_rg_name` and `managed_identity_oidc_issuer_url` are required."
   }

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -242,15 +242,35 @@ The following requirements are needed by this module:
 
 - [[requirement_utils]] <<requirement_utils,utils>> (>= 1)
 
+=== Providers
+
+The following providers are used by this module:
+
+- [[provider_aws]] <<provider_aws,aws>>
+
 === Modules
 
 The following Modules are called:
+
+==== [[module_iam_assumable_role_thanos]] <<module_iam_assumable_role_thanos,iam_assumable_role_thanos>>
+
+Source: terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc
+
+Version: ~> 5.0
 
 ==== [[module_thanos]] <<module_thanos,thanos>>
 
 Source: ../
 
 Version:
+
+=== Resources
+
+The following resources are used by this module:
+
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.thanos] (resource)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.thanos] (data source)
+- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.thanos] (data source)
 
 === Required Inputs
 
@@ -260,13 +280,16 @@ The following input variables are required:
 
 Description: AWS S3 bucket configuration values for the bucket where the archived metrics will be stored.
 
+An IAM role is required to give the Thanos components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+
 Type:
 [source,hcl]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -324,7 +347,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -390,6 +413,88 @@ Type: `any`
 
 Default: `{}`
 
+==== [[input_resources]] <<input_resources,resources>>
+
+Description: Resource limits and requests for Thanos' components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+Type:
+[source,hcl]
+----
+object({
+
+    query = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    query_frontend = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    bucketweb = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    compactor = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    storegateway = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    redis = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
+Default: `{}`
+
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
 Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
@@ -424,12 +529,31 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[requirement_utils]] <<requirement_utils,utils>> |>= 1
 |===
 
+= Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_aws]] <<provider_aws,aws>> |n/a
+|===
+
 = Modules
 
 [cols="a,a,a",options="header,autowidth"]
 |===
 |Name |Source |Version
+|[[module_iam_assumable_role_thanos]] <<module_iam_assumable_role_thanos,iam_assumable_role_thanos>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |~> 5.0
 |[[module_thanos]] <<module_thanos,thanos>> |../ |
+|===
+
+= Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy[aws_iam_policy.thanos] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document[aws_iam_policy_document.thanos] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket[aws_s3_bucket.thanos] |data source
 |===
 
 = Inputs
@@ -439,14 +563,18 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |Name |Description |Type |Default |Required
 |[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 |AWS S3 bucket configuration values for the bucket where the archived metrics will be stored.
+
+An IAM role is required to give the Thanos components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+
 |
 
 [source]
 ----
 object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
 ----
 
@@ -492,7 +620,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
@@ -548,6 +676,89 @@ object({
 |[[input_thanos]] <<input_thanos,thanos>>
 |Most frequently used Thanos settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 |`any`
+|`{}`
+|no
+
+|[[input_resources]] <<input_resources,resources>>
+|Resource limits and requests for Thanos' components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
+
+IMPORTANT: These are not production values. You should always adjust them to your needs.
+
+|
+
+[source]
+----
+object({
+
+    query = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    query_frontend = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    bucketweb = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "50m")
+        memory = optional(string, "128Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "128Mi")
+      }), {})
+    }), {})
+
+    compactor = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    storegateway = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "250m")
+        memory = optional(string, "512Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+    redis = optional(object({
+      requests = optional(object({
+        cpu    = optional(string, "200m")
+        memory = optional(string, "256Mi")
+      }), {})
+      limits = optional(object({
+        cpu    = optional(string)
+        memory = optional(string, "512Mi")
+      }), {})
+    }), {})
+
+  })
+----
+
 |`{}`
 |no
 

--- a/eks/README.adoc
+++ b/eks/README.adoc
@@ -17,9 +17,9 @@ module "thanos" {
   argocd_namespace = module.argocd_bootstrap.argocd_namespace
 
   metrics_storage = {
-    bucket_id    = aws_s3_bucket.thanos_metrics_storage.id
-    region       = aws_s3_bucket.thanos_metrics_storage.region
-    iam_role_arn = module.iam_assumable_role_thanos.iam_role_arn
+    bucket_id               = resource.aws_s3_bucket.thanos_metrics_storage.id
+    create_role             = true
+    cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
   }
   thanos = {
     oidc = module.oidc.oidc
@@ -34,9 +34,14 @@ module "thanos" {
 }  
 ----
 
-As you can see, a minimum requirement for this module is an S3 bucket with an IAM policy attached and an OIDC provider (more information below).
+As you can see, a minimum requirement for this module is an S3 bucket and an OIDC provider (more information below).
 
-IMPORTANT: You are in charge of creating a S3 bucket for Thanos to store the archived metrics. We've decided to keep the creation of this bucket outside of this module, mainly because the persistence of the data should not be related to the instantiation of the module itself.
+IMPORTANT
+====
+You are in charge of creating a S3 bucket for Thanos to store the archived metrics. We've decided to keep the creation of this bucket outside of this module, mainly because the persistence of the data should not be related to the instantiation of the module itself.
+
+However, the IAM role used to give permissions to the Thanos components to access the bucket can be created by the module itself. If you want to create the role, you can set the attribute `create_role` to `true` and the module will create the role for you. If you already have a role created, you can pass the ARN of the role to the module using the attribute `iam_role_arn`.
+====
 
 TIP: Check the xref:ROOT:ROOT:tutorials/deploy_eks.adoc[EKS deployment example] to see how to create the S3 bucket and to better understand the values passed on the example above.
 
@@ -55,9 +60,9 @@ module "thanos" {
   argocd_namespace = module.argocd_bootstrap.argocd_namespace
 
   metrics_storage = {
-    bucket_id    = aws_s3_bucket.thanos_metrics_storage.id
-    region       = aws_s3_bucket.thanos_metrics_storage.region
-    iam_role_arn = module.iam_assumable_role_thanos.iam_role_arn
+    bucket_id               = resource.aws_s3_bucket.thanos_metrics_storage.id
+    create_role             = true
+    cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
   }
 
   thanos = {
@@ -128,9 +133,9 @@ module "thanos" {
   argocd_namespace = module.argocd_bootstrap.argocd_namespace
 
   metrics_storage = {
-    bucket_id    = aws_s3_bucket.thanos_metrics_storage.id
-    region       = aws_s3_bucket.thanos_metrics_storage.region
-    iam_role_arn = module.iam_assumable_role_thanos.iam_role_arn
+    bucket_id               = resource.aws_s3_bucket.thanos_metrics_storage.id
+    create_role             = true
+    cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
   }
 
   thanos = {
@@ -168,6 +173,14 @@ module "thanos" {
   }
 }
 ----
+
+=== S3 bucket and IAM role
+
+Thanos needs an S3 bucket to store the archived metrics. The bucket can be created and its ID should be passed to the module, along with the attribute `create_role` explicitly set. Set it to true if you want the module to create the required IAM role.
+
+However, if you want to create and manage this IAM role yourself, you can simply pass the ARN of the role to the module using the attribute `iam_role_arn` while setting the attribute `create_role` to `false`.
+
+TIP: The code https://github.com/camptocamp/devops-stack/blob/main/examples/eks/s3_thanos.tf.disabled[in this example] should help you create the IAM policy and role with the required permissions.
 
 === OIDC
 
@@ -377,88 +390,6 @@ Type: `any`
 
 Default: `{}`
 
-==== [[input_resources]] <<input_resources,resources>>
-
-Description: Resource limits and requests for Thanos' components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
-
-IMPORTANT: These are not production values. You should always adjust them to your needs.
-
-Type:
-[source,hcl]
-----
-object({
-
-    query = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "512Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    query_frontend = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    bucketweb = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "50m")
-        memory = optional(string, "128Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "128Mi")
-      }), {})
-    }), {})
-
-    compactor = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    storegateway = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "512Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    redis = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "200m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-  })
-----
-
-Default: `{}`
-
 ==== [[input_enable_service_monitor]] <<input_enable_service_monitor,enable_service_monitor>>
 
 Description: Boolean to enable the deployment of a service monitor for Prometheus. This also enables the deployment of default Prometheus rules and Grafana dashboards, which are embedded inside the chart templates and are taken from the official Thanos examples, available https://github.com/thanos-io/thanos/blob/main/examples/alerts/alerts.yaml[here].
@@ -617,89 +548,6 @@ object({
 |[[input_thanos]] <<input_thanos,thanos>>
 |Most frequently used Thanos settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 |`any`
-|`{}`
-|no
-
-|[[input_resources]] <<input_resources,resources>>
-|Resource limits and requests for Thanos' components. Follow the style on https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[official documentation] to understand the format of the values.
-
-IMPORTANT: These are not production values. You should always adjust them to your needs.
-
-|
-
-[source]
-----
-object({
-
-    query = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "512Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    query_frontend = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    bucketweb = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "50m")
-        memory = optional(string, "128Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "128Mi")
-      }), {})
-    }), {})
-
-    compactor = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    storegateway = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "250m")
-        memory = optional(string, "512Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-    redis = optional(object({
-      requests = optional(object({
-        cpu    = optional(string, "200m")
-        memory = optional(string, "256Mi")
-      }), {})
-      limits = optional(object({
-        cpu    = optional(string)
-        memory = optional(string, "512Mi")
-      }), {})
-    }), {})
-
-  })
-----
-
 |`{}`
 |no
 

--- a/eks/extra-variables.tf
+++ b/eks/extra-variables.tf
@@ -1,8 +1,18 @@
 variable "metrics_storage" {
-  description = "AWS S3 bucket configuration values for the bucket where the archived metrics will be stored."
+  description = <<-EOT
+    AWS S3 bucket configuration values for the bucket where the archived metrics will be stored.
+
+    An IAM role is required to give the Thanos components read and write access to the S3 bucket. You can create this role yourself or let the module create it for you. If you want the module to create the role, you need to provide the OIDC issuer's URL for the EKS cluster. If you create the role yourself, you need to provide the ARN of the IAM role you created.
+  EOT
   type = object({
-    bucket_id    = string
-    region       = string
-    iam_role_arn = string
+    bucket_id               = string
+    create_role             = bool
+    iam_role_arn            = optional(string, null)
+    cluster_oidc_issuer_url = optional(string, null)
   })
+
+  validation {
+    condition     = var.metrics_storage.create_role ? var.metrics_storage.cluster_oidc_issuer_url != null : var.metrics_storage.iam_role_arn != null
+    error_message = "If you want to create a role, you need to provide the OIDC issuer's URL for the EKS cluster. Otherwise, you need to provide the ARN of the IAM role you created."
+  }
 }

--- a/eks/locals.tf
+++ b/eks/locals.tf
@@ -1,13 +1,14 @@
 locals {
+  iam_role_arn = var.metrics_storage.create_role ? module.iam_assumable_role_thanos.iam_role_arn : var.metrics_storage.iam_role_arn
+
   helm_values = [{
     thanos = {
-
       objstoreConfig = {
         type = "S3"
         config = {
-          bucket             = "${var.metrics_storage.bucket_id}"
+          bucket             = "${data.aws_s3_bucket.thanos.id}"
           endpoint           = "s3.amazonaws.com" # Value explicitly specified by Thanos docs for Amazon S3 buckets
-          region             = "${var.metrics_storage.region}"
+          region             = "${data.aws_s3_bucket.thanos.region}"
           signature_version2 = false
           insecure           = false
         }
@@ -18,25 +19,24 @@ locals {
       bucketweb = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = var.metrics_storage.iam_role_arn
+            "eks.amazonaws.com/role-arn" = local.iam_role_arn
           }
         }
       }
       compactor = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = var.metrics_storage.iam_role_arn
+            "eks.amazonaws.com/role-arn" = local.iam_role_arn
           }
         }
       }
       storegateway = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = var.metrics_storage.iam_role_arn
+            "eks.amazonaws.com/role-arn" = local.iam_role_arn
           }
         }
       }
-
     }
   }]
 }

--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,3 +1,52 @@
+data "aws_s3_bucket" "thanos" {
+  bucket = var.metrics_storage.bucket_id
+}
+
+data "aws_iam_policy_document" "thanos" {
+  count = var.metrics_storage.create_role ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      data.aws_s3_bucket.thanos.arn,
+      format("%s/*", data.aws_s3_bucket.thanos.arn),
+    ]
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "thanos" {
+  count = var.metrics_storage.create_role ? 1 : 0
+
+  name_prefix = "thanos-s3-"
+  description = "Thanos IAM policy for accessing the S3 bucket named ${data.aws_s3_bucket.thanos.id}"
+  policy      = data.aws_iam_policy_document.thanos[0].json
+}
+
+module "iam_assumable_role_thanos" {
+  source                     = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                    = "~> 5.0"
+  create_role                = var.metrics_storage.create_role
+  number_of_role_policy_arns = 1
+  role_name_prefix           = "thanos-s3-"
+  provider_url               = try(trimprefix(var.metrics_storage.cluster_oidc_issuer_url, "https://"), "")
+  role_policy_arns           = [try(resource.aws_iam_policy.thanos[0].arn, null)]
+
+  # List of ServiceAccounts that have permission to attach to this IAM role
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:thanos:thanos-bucketweb",
+    "system:serviceaccount:thanos:thanos-storegateway",
+    "system:serviceaccount:thanos:thanos-compactor",
+  ]
+}
+
 module "thanos" {
   source = "../"
 

--- a/kind/README.adoc
+++ b/kind/README.adoc
@@ -245,7 +245,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -497,7 +497,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -194,7 +194,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v4.0.0"`
+Default: `"v4.1.0"`
 
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
@@ -451,7 +451,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v4.0.0"`
+|`"v4.1.0"`
 |no
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>


### PR DESCRIPTION
## Description of the changes

This commit solves ISDEVOPS-279 and ISDEVOPS-283 for the EKS variant. That is, it adds support for creating the IAM role automatically inside the modules while also giving the chance to provide a custom one managed by the user.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] Yes - because the Terraform variable was changed

## Tests executed on which distribution(s)

- [x] EKS (AWS)