### PR TITLE
feat!: remove the cluster_id variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,11 +36,11 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
-
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
 - [[provider_null]] <<provider_null,null>> (>= 3)
 
@@ -301,10 +301,10 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_null]] <<provider_null,null>> |>= 3
 |[[provider_random]] <<provider_random,random>> |>= 3
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
+|[[provider_null]] <<provider_null,null>> |>= 3
 |===
 
 = Resources

--- a/sks/README.adoc
+++ b/sks/README.adoc
@@ -119,12 +119,6 @@ Version:
 
 The following input variables are required:
 
-==== [[input_cluster_id]] <<input_cluster_id,cluster_id>>
-
-Description: ID of the SKS cluster.
-
-Type: `string`
-
 ==== [[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 
 Description: Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored.
@@ -389,12 +383,6 @@ Description: ID to pass other modules in order to refer to this module as a depe
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
-|[[input_cluster_id]] <<input_cluster_id,cluster_id>>
-|ID of the SKS cluster.
-|`string`
-|n/a
-|yes
-
 |[[input_metrics_storage]] <<input_metrics_storage,metrics_storage>>
 |Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored.
 |

--- a/sks/extra-variables.tf
+++ b/sks/extra-variables.tf
@@ -1,8 +1,3 @@
-variable "cluster_id" {
-  description = "ID of the SKS cluster."
-  type        = string
-}
-
 variable "metrics_storage" {
   description = "Exoscale SOS bucket configuration values for the bucket where the archived metrics will be stored."
   type = object({

--- a/sks/locals.tf
+++ b/sks/locals.tf
@@ -1,7 +1,6 @@
 locals {
   helm_values = [{
     thanos = {
-      clusterDomain = "${var.cluster_id}.cluster.local"
       objstoreConfig = {
         type = "S3"
         config = {


### PR DESCRIPTION
## Description of the changes

When creating an SKS cluster, Exoscale used to provision a cluster domain value of `<CLUSTER_ID>.cluster.local`. This is the legacy value for SKS cluster domain.

They recently transitioned to provisioning SKS cluster with the default cluster domain value of `cluster.local`.

Consequently, we need to remove the adaptations on our modules that were there to support this bizarre, and now legacy, behavior.

## Breaking change

- [x] Yes (in the module itself): the variable `cluster_id` was removed from the SKS variant

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)
