### PR TITLE
fix: grafana panels uses angular deprecated plugin

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,9 +36,9 @@ The following requirements are needed by this module:
 
 The following providers are used by this module:
 
-- [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
-
 - [[provider_random]] <<provider_random,random>> (>= 3)
+
+- [[provider_argocd]] <<provider_argocd,argocd>> (>= 6)
 
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 

--- a/charts/thanos/dashboards/compactor.json
+++ b/charts/thanos/dashboards/compactor.json
@@ -1,1819 +1,2532 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for compactions against blocks that are stored in the bucket by compaction resolution.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+   "id": 44,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 20,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Group Compaction",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for compactions against blocks that are stored in the bucket by compaction resolution.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, resolution) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "compaction {{job}} {{resolution}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, resolution) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "compaction {{job}} {{resolution}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 21,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Downsample",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction resolution.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 9
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, resolution) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "downsample {{job}} {{resolution}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 9
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_downsample_failed_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 22,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Garbage Collection",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 17
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "garbage collection {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed garbage collections.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 17
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_garbage_collection_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to execute garbage collection in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Group Compaction",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for downsampling against blocks that are stored in the bucket by compaction resolution.",
-               "fill": 10,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, resolution) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "downsample {{job}} {{resolution}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed downsampling against blocks that are stored in the bucket.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_downsample_failed_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_downsample_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 17
+       },
+       "id": 7,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 23,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Blocks deletion",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows deletion rate of blocks already marked for deletion.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 25
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_blocks_cleaned_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "Blocks cleanup {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Deletion Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows deletion failures rate of blocks already marked for deletion.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Downsample",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for removals of blocks if their data is available as part of a block with a higher compaction level.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 25
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_block_cleanup_failures_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "Blocks cleanup failures {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Deletion Error Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate at which blocks are marked for deletion (from GC and retention policy).",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "garbage collection {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 25
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_blocks_marked_for_deletion_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "Blocks marked {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Marking Rate",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 24,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Sync Meta",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 33
+       },
+       "id": 11,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "sync {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed meta file sync.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 33
+       },
+       "id": 12,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_blocks_meta_sync_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to execute meta file sync, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed garbage collections.",
-               "fill": 10,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_garbage_collection_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_compact_garbage_collection_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute garbage collection in quantiles.",
-               "fill": 1,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 33
+       },
+       "id": 13,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 40
+       },
+       "id": 25,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Object Store Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for operations against the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Garbage Collection",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows deletion rate of blocks already marked for deletion.",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 41
+       },
+       "id": 14,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{operation}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_blocks_cleaned_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Blocks cleanup {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Deletion Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 41
+       },
+       "id": 15,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows deletion failures rate of blocks already marked for deletion.",
-               "fill": 1,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_block_cleanup_failures_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Blocks cleanup failures {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Deletion Error Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate at which blocks are marked for deletion (from GC and retention policy).",
-               "fill": 1,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_blocks_marked_for_deletion_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Blocks marked {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Marking Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 41
+       },
+       "id": 16,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": true,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 48
+       },
+       "id": 26,
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "dashLength": 10,
+           "dashes": false,
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "fill": 1,
+           "gridPos": {
+             "h": 7,
+             "w": 8,
+             "x": 0,
+             "y": 49
+           },
+           "id": 17,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 1,
+           "links": [],
+           "nullPointMode": "null as zero",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "spaceLength": 10,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "alloc all {{instance}}",
+               "step": 10
+             },
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Blocks deletion",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for all meta files from blocks in the bucket into the memory.",
-               "fill": 10,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "alloc heap {{instance}}",
+               "step": 10
+             },
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "sync {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "alloc rate all {{instance}}",
+               "step": 10
+             },
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "alloc rate heap {{instance}}",
+               "step": 10
+             },
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "inuse heap {{instance}}",
+               "step": 10
+             },
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed meta file sync.",
-               "fill": 10,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "inuse stack {{instance}}",
+               "step": 10
+             }
+           ],
+           "thresholds": [],
+           "title": "Memory Used",
+           "tooltip": {
+             "shared": false,
+             "sort": 0,
+             "value_type": "individual"
+           },
+           "type": "graph",
+           "xaxis": {
+             "mode": "time",
+             "show": true,
+             "values": []
+           },
+           "yaxes": [
+             {
+               "format": "bytes",
+               "logBase": 1,
+               "min": 0,
+               "show": true
+             },
+             {
+               "format": "short",
+               "logBase": 1,
+               "show": false
+             }
+           ]
+         },
+         {
+           "aliasColors": {},
+           "bars": false,
+           "dashLength": 10,
+           "dashes": false,
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "fill": 1,
+           "gridPos": {
+             "h": 7,
+             "w": 8,
+             "x": 8,
+             "y": 49
+           },
+           "id": 18,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 1,
+           "links": [],
+           "nullPointMode": "null as zero",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "spaceLength": 10,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_blocks_meta_sync_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_blocks_meta_syncs_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "expr": "go_goroutines{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{instance}}",
+               "step": 10
+             }
+           ],
+           "thresholds": [],
+           "title": "Goroutines",
+           "tooltip": {
+             "shared": false,
+             "sort": 0,
+             "value_type": "individual"
+           },
+           "type": "graph",
+           "xaxis": {
+             "mode": "time",
+             "show": true,
+             "values": []
+           },
+           "yaxes": [
+             {
+               "format": "short",
+               "logBase": 1,
+               "min": 0,
+               "show": true
+             },
+             {
+               "format": "short",
+               "logBase": 1,
+               "show": false
+             }
+           ]
+         },
+         {
+           "aliasColors": {},
+           "bars": false,
+           "dashLength": 10,
+           "dashes": false,
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "fill": 1,
+           "gridPos": {
+             "h": 7,
+             "w": 8,
+             "x": 16,
+             "y": 49
+           },
+           "id": 19,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 1,
+           "links": [],
+           "nullPointMode": "null as zero",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "spaceLength": 10,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "datasource": {
+                 "uid": "$datasource"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute meta file sync, in quantiles.",
-               "fill": 1,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Sync Meta",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for operations against the bucket.",
-               "fill": 10,
-               "id": 14,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{operation}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
-               "fill": 10,
-               "id": 15,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
-               "fill": 1,
-               "id": 16,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Object Store Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 17,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse stack {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Used",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 18,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 19,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_gc_duration_seconds{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{quantile}} {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "GC Time Quantiles",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resources",
-         "titleSize": "h6"
-      }
+               "expr": "go_gc_duration_seconds{job=~\"$job\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{quantile}} {{instance}}",
+               "step": 10
+             }
+           ],
+           "thresholds": [],
+           "title": "GC Time Quantiles",
+           "tooltip": {
+             "shared": false,
+             "sort": 0,
+             "value_type": "individual"
+           },
+           "type": "graph",
+           "xaxis": {
+             "mode": "time",
+             "show": true,
+             "values": []
+           },
+           "yaxes": [
+             {
+               "format": "short",
+               "logBase": 1,
+               "min": 0,
+               "show": true
+             },
+             {
+               "format": "short",
+               "logBase": 1,
+               "show": false
+             }
+           ]
+         }
+       ],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Resources",
+       "type": "row"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
          },
-         {
-            "allValue": null,
-            "current": {
-               "text": "all",
-               "value": "$__all"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "job",
-            "multi": false,
-            "name": "job",
-            "options": [ ],
-            "query": "label_values(up{job=~\".*thanos-compact.*\"}, job)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         }
-      ]
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       },
+       {
+         "current": {
+           "selected": false,
+           "text": "All",
+           "value": "$__all"
+         },
+         "datasource": {
+           "type": "prometheus",
+           "uid": "$datasource"
+         },
+         "definition": "",
+         "hide": 0,
+         "includeAll": true,
+         "label": "job",
+         "multi": false,
+         "name": "job",
+         "options": [],
+         "query": "label_values(up{job=~\".*thanos-compact.*\"}, job)",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 2,
+         "tagValuesQuery": "",
+         "tagsQuery": "",
+         "type": "query",
+         "useTags": false
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Compactor",
-   "uid": "651943d05a8123e32867b4673963f42b",
-   "version": 0
-}
+   "uid": "651943d05a8123e32867b4673963f42",
+   "version": 17,
+   "weekStart": ""
+ }

--- a/charts/thanos/dashboards/overview.json
+++ b/charts/thanos/dashboards/overview.json
@@ -1,2176 +1,3282 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of requests against /query for the given time.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests against /query.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{handler=\"query\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"query\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests.",
-               "fill": 1,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query\"}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Latency 99th Percentile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Instant Query",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of requests against /query_range for the given time range.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests against /query_range.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{handler=\"query_range\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests.",
-               "fill": 1,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Query",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Query",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query_range\"}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Latency 99th Percentile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Range Query",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests from queriers.",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Store",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Store",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC (Unary) Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Store",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Store",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC (Unary) Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers.",
-               "fill": 1,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Store",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Store",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC Latency 99th Percentile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Store",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests from queriers.",
-               "fill": 10,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Sidecar",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Sidecar",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC (Unary) Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
-               "fill": 10,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Sidecar",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Sidecar",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC (Unary) Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
-               "fill": 1,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Sidecar",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Sidecar",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "gRPC (Unary) Latency 99th Percentile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Sidecar",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of incoming requests.",
-               "fill": 10,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Receiver",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Receiver",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Incoming Requests Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled incoming requests.",
-               "fill": 10,
-               "id": 14,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Receiver",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Receiver",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{handler=\"receive\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Incoming Requests Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle incoming requests.",
-               "fill": 1,
-               "id": 15,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Receiver",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Receiver",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"receive\"}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Incoming Requests Latency 99th Percentile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Receiver",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of alerts that successfully sent to alert manager.",
-               "fill": 10,
-               "id": 16,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Rule",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Rule",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alertmanager}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Alert Sent Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of sent alerts.",
-               "fill": 10,
-               "id": 17,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Rule",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Rule",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_alert_sender_errors_total{}[$interval])) / sum by (job) (rate(thanos_alert_sender_alerts_sent_total{}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Alert Sent Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to send alerts to alert manager.",
-               "fill": 1,
-               "id": 18,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Rule",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Rule",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{}[$interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} P99",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "warning",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.5,
-                     "yaxis": "left"
-                  },
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 1,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Alert Sent Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rule",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for compactions against blocks that are stored in the bucket.",
-               "fill": 10,
-               "id": 19,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Compactor",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Compactor",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_group_compactions_total{}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "compaction {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Compaction Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
-               "fill": 10,
-               "id": 20,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [
-                  {
-                     "dashboard": "Thanos / Compactor",
-                     "includeVars": true,
-                     "keepTime": true,
-                     "title": "Thanos / Compactor",
-                     "type": "dashboard"
-                  }
-               ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Compaction Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Compactor",
-         "titleSize": "h6"
-      }
+   "id": 45,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 21,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Instant Query",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of requests against /query for the given time.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests against /query.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 1
+       },
+       "id": 2,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{handler=\"query\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"query\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 1
+       },
+       "id": 3,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query\"}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Latency 99th Percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 22,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Range Query",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of requests against /query_range for the given time range.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 9
+       },
+       "id": 4,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests against /query_range.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 9
+       },
+       "id": 5,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{handler=\"query_range\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"query_range\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 9
+       },
+       "id": 6,
+       "links": [
+         {
+           "title": "Thanos / Query",
+           "url": "dashboard/db/thanos-query?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"query_range\"}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Latency 99th Percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 23,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Store",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Unary gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 17
+       },
+       "id": 7,
+       "links": [
+         {
+           "title": "Thanos / Store",
+           "url": "dashboard/db/thanos-store?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC (Unary) Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 17
+       },
+       "id": 8,
+       "links": [
+         {
+           "title": "Thanos / Store",
+           "url": "dashboard/db/thanos-store?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC (Unary) Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 17
+       },
+       "id": 9,
+       "links": [
+         {
+           "title": "Thanos / Store",
+           "url": "dashboard/db/thanos-store?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC Latency 99th Percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 24,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Sidecar",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Unary gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 25
+       },
+       "id": 10,
+       "links": [
+         {
+           "title": "Thanos / Sidecar",
+           "url": "dashboard/db/thanos-sidecar?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC (Unary) Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 25
+       },
+       "id": 11,
+       "links": [
+         {
+           "title": "Thanos / Sidecar",
+           "url": "dashboard/db/thanos-sidecar?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC (Unary) Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 25
+       },
+       "id": 12,
+       "links": [
+         {
+           "title": "Thanos / Sidecar",
+           "url": "dashboard/db/thanos-sidecar?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{grpc_type=\"unary\"}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "gRPC (Unary) Latency 99th Percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 25,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Receiver",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of incoming requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 33
+       },
+       "id": 13,
+       "links": [
+         {
+           "title": "Thanos / Receiver",
+           "url": "dashboard/db/thanos-receiver?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Incoming Requests Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled incoming requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 33
+       },
+       "id": 14,
+       "links": [
+         {
+           "title": "Thanos / Receiver",
+           "url": "dashboard/db/thanos-receiver?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{handler=\"receive\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{handler=\"receive\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Incoming Requests Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle incoming requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 33
+       },
+       "id": 15,
+       "links": [
+         {
+           "title": "Thanos / Receiver",
+           "url": "dashboard/db/thanos-receiver?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{handler=\"receive\"}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Incoming Requests Latency 99th Percentile",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 40
+       },
+       "id": 26,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Rule",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of alerts that successfully sent to alert manager.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 41
+       },
+       "id": 16,
+       "links": [
+         {
+           "title": "Thanos / Rule",
+           "url": "dashboard/db/thanos-rule?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{alertmanager}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Alert Sent Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of sent alerts.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 41
+       },
+       "id": 17,
+       "links": [
+         {
+           "title": "Thanos / Rule",
+           "url": "dashboard/db/thanos-rule?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_alert_sender_errors_total{}[$interval])) / sum by (job) (rate(thanos_alert_sender_alerts_sent_total{}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Alert Sent Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to send alerts to alert manager.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "line+area"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "transparent",
+                 "value": null
+               },
+               {
+                 "color": "orange",
+                 "value": 0.5
+               },
+               {
+                 "color": "red",
+                 "value": 1
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 41
+       },
+       "id": 18,
+       "links": [
+         {
+           "title": "Thanos / Rule",
+           "url": "dashboard/db/thanos-rule?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_alert_sender_latency_seconds_bucket{}[$interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} P99",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Alert Sent Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 48
+       },
+       "id": 27,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Compactor",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for compactions against blocks that are stored in the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 49
+       },
+       "id": 19,
+       "links": [
+         {
+           "title": "Thanos / Compactor",
+           "url": "dashboard/db/thanos-compactor?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_group_compactions_total{}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "compaction {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Compaction Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed compactions against blocks that are stored in the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 49
+       },
+       "id": 20,
+       "links": [
+         {
+           "title": "Thanos / Compactor",
+           "url": "dashboard/db/thanos-compactor?$__url_time_range&$__all_variables"
+         }
+       ],
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_compact_group_compactions_failures_total{}[$interval])) / sum by (job) (rate(thanos_compact_group_compactions_total{}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Compaction Errors",
+       "type": "timeseries"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
-         }
-      ]
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
+         },
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Overview",
    "uid": "0cb8830a6e957978796729870f560cda",
-   "version": 0
-}
+   "version": 21,
+   "weekStart": ""
+ }

--- a/charts/thanos/dashboards/query-frontend.json
+++ b/charts/thanos/dashboards/query-frontend.json
@@ -1,1116 +1,1632 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of requests against Query Frontend for the given time.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+   "id": 46,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 12,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Query Frontend API",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of requests against Query Frontend for the given time.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of requests",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate of requests",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of queries passing through Query Frontend",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 6,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(thanos_query_frontend_queries_total{job=~\"$job\", op=\"query_range\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate of queries",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests against Query Frontend.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of queries passing through Query Frontend",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 12,
+         "y": 1
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(thanos_query_frontend_queries_total{job=~\"$job\", op=\"query_range\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of queries",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests against Query Frontend.",
-               "fill": 10,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query-frontend\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 18,
+         "y": 1
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 13,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Cache Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show rate of cache requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests in quantiles.",
-               "fill": 1,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 0,
+         "y": 9
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, tripperware) (rate(cortex_cache_request_duration_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{tripperware}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show rate of Querier cache gets vs misses.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query-frontend\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 6,
+         "y": 9
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, tripperware) (rate(querier_cache_gets_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "Cache gets - {{job}} {{tripperware}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, tripperware) (rate(querier_cache_misses_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "Cache misses - {{job}} {{tripperware}}",
+           "refId": "B",
+           "step": 10
+         }
+       ],
+       "title": "Querier cache gets vs misses",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of cortex fetched keys.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 12,
+         "y": 9
+       },
+       "id": 7,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, tripperware) (rate(cortex_cache_fetched_keys_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{tripperware}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Cortex fetched keys",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of cortex cache hits.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Query Frontend API",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show rate of cache requests.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 18,
+         "y": 9
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, tripperware) (rate(cortex_cache_hits_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{tripperware}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Cortex cache hits",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 14,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Resources",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, tripperware) (rate(cortex_cache_request_duration_seconds_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{tripperware}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 17
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc all {{instance}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc heap {{instance}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate all {{instance}}",
+           "refId": "C",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate heap {{instance}}",
+           "refId": "D",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse heap {{instance}}",
+           "refId": "E",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse stack {{instance}}",
+           "refId": "F",
+           "step": 10
+         }
+       ],
+       "title": "Memory Used",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 17
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_goroutines{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Goroutines",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show rate of Querier cache gets vs misses.",
-               "fill": 10,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, tripperware) (rate(querier_cache_gets_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Cache gets - {{job}} {{tripperware}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job, tripperware) (rate(querier_cache_misses_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Cache misses - {{job}} {{tripperware}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Querier cache gets vs misses",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of cortex fetched keys.",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, tripperware) (rate(cortex_cache_fetched_keys_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{tripperware}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cortex fetched keys",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of cortex cache hits.",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, tripperware) (rate(cortex_cache_hits_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{tripperware}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cortex cache hits",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Cache Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse stack {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Used",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_gc_duration_seconds{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{quantile}} {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "GC Time Quantiles",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resources",
-         "titleSize": "h6"
-      }
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 17
+       },
+       "id": 11,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_gc_duration_seconds{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}} {{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "GC Time Quantiles",
+       "type": "timeseries"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
          },
-         {
-            "allValue": null,
-            "current": {
-               "text": "all",
-               "value": "$__all"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "job",
-            "multi": false,
-            "name": "job",
-            "options": [ ],
-            "query": "label_values(up{job=~\".*thanos-query-frontend.*\"}, job)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         }
-      ]
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       },
+       {
+         "current": {
+           "selected": false,
+           "text": "All",
+           "value": "$__all"
+         },
+         "datasource": {
+           "type": "prometheus",
+           "uid": "$datasource"
+         },
+         "definition": "",
+         "hide": 0,
+         "includeAll": true,
+         "label": "job",
+         "multi": false,
+         "name": "job",
+         "options": [],
+         "query": "label_values(up{job=~\".*thanos-query-frontend.*\"}, job)",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 2,
+         "tagValuesQuery": "",
+         "tagsQuery": "",
+         "type": "query",
+         "useTags": false
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Query Frontend",
    "uid": "7c68ed2ef2355474f058dd27f0471f7a",
-   "version": 0
-}
+   "version": 12,
+   "weekStart": ""
+ }

--- a/charts/thanos/dashboards/query.json
+++ b/charts/thanos/dashboards/query.json
@@ -1,1963 +1,3280 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of requests against /query for the given time.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+   "id": 47,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 19,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Instant Query API",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of requests against /query for the given time.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests against /query.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests against /query.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests in quantiles.",
-               "fill": 1,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 1
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 20,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Range Query API",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of requests against /query_range for the given time range.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/1../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/2../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/3../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/4../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/5../"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 9
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{handler}} {{code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests against /query_range.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Instant Query API",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of requests against /query_range for the given time range.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 9
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/1../",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/2../",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/3../",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/4../",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/5../",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, handler, code) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{handler}} {{code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests against /query_range.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, code) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\",code=~\"5..\"}[$interval])) / ignoring (code) group_left() sum by (job) (rate(http_requests_total{job=~\"$job\", handler=\"query_range\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 9
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 21,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Unary)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Unary gRPC requests from other queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests in quantiles.",
-               "fill": 1,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 17
+       },
+       "id": 7,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from other queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=\"query_range\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 17
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from other queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Range Query API",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests from other queriers.",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from other queriers.",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 17
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 22,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Stream)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Streamed gRPC requests from other queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 25
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from other queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 25
+       },
+       "id": 11,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from other queriers, in quantiles",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from other queriers, in quantiles.",
-               "fill": 1,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Unary)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Streamed gRPC requests from other queriers.",
-               "fill": 10,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 25
+       },
+       "id": 12,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 23,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "DNS",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of DNS lookups to discover stores.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 0,
+         "y": 33
+       },
+       "id": 13,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "lookups {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of failures compared to the total number of executed DNS lookups.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from other queriers.",
-               "fill": 10,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 12,
+         "x": 12,
+         "y": 33
+       },
+       "id": 14,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 40
+       },
+       "id": 24,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Query Concurrency",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows available capacity of processing queries in parallel.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_client_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_client_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 24,
+         "x": 0,
+         "y": 41
+       },
+       "id": 15,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "max_over_time(thanos_query_concurrent_gate_queries_max{job=~\"$job\"}[$__rate_interval]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{job=~\"$job\"}[$__rate_interval])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} - {{pod}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Concurrent Capacity",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 48
+       },
+       "id": 25,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Resources",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 49
+       },
+       "id": 16,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc all {{instance}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc heap {{instance}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate all {{instance}}",
+           "refId": "C",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate heap {{instance}}",
+           "refId": "D",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse heap {{instance}}",
+           "refId": "E",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse stack {{instance}}",
+           "refId": "F",
+           "step": 10
+         }
+       ],
+       "title": "Memory Used",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from other queriers, in quantiles",
-               "fill": 1,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 49
+       },
+       "id": 17,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_goroutines{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Goroutines",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_client_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Stream)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of DNS lookups to discover stores.",
-               "fill": 1,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "lookups {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of failures compared to the total number of executed DNS lookups.",
-               "fill": 10,
-               "id": 14,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_query_store_apis_dns_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_query_store_apis_dns_lookups_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "DNS",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows available capacity of processing queries in parallel.",
-               "fill": 1,
-               "id": 15,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "max_over_time(thanos_query_concurrent_gate_queries_max{job=~\"$job\"}[$__rate_interval]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{job=~\"$job\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} - {{pod}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Concurrent Capacity",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Query Concurrency",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 16,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse stack {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Used",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 17,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 18,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_gc_duration_seconds{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{quantile}} {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "GC Time Quantiles",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resources",
-         "titleSize": "h6"
-      }
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 49
+       },
+       "id": 18,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_gc_duration_seconds{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}} {{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "GC Time Quantiles",
+       "type": "timeseries"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
          },
-         {
-            "allValue": null,
-            "current": {
-               "text": "all",
-               "value": "$__all"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "job",
-            "multi": false,
-            "name": "job",
-            "options": [ ],
-            "query": "label_values(up{job=~\".*thanos-query.*\"}, job)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         }
-      ]
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       },
+       {
+         "current": {
+           "selected": false,
+           "text": "All",
+           "value": "$__all"
+         },
+         "datasource": {
+           "type": "prometheus",
+           "uid": "$datasource"
+         },
+         "definition": "",
+         "hide": 0,
+         "includeAll": true,
+         "label": "job",
+         "multi": false,
+         "name": "job",
+         "options": [],
+         "query": "label_values(up{job=~\".*thanos-query.*\"}, job)",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 2,
+         "tagValuesQuery": "",
+         "tagsQuery": "",
+         "type": "query",
+         "useTags": false
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Query",
    "uid": "af36c91291a603f1d9fbdabdd127ac4a",
-   "version": 0
-}
+   "version": 19,
+   "weekStart": ""
+ }

--- a/charts/thanos/dashboards/sidecar.json
+++ b/charts/thanos/dashboards/sidecar.json
@@ -1,1505 +1,2489 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests from queriers.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+   "id": 48,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 14,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Unary)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Unary gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
-               "fill": 1,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 1
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 15,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Stream)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Streamed gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 9
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Unary)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Streamed gRPC requests from queriers.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 9
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 9
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 16,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Last Updated",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows the relative time of last successful upload to the object-store bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "thresholds"
+           },
+           "custom": {
+             "cellOptions": {
+               "type": "auto"
+             },
+             "inspect": false
+           },
+           "decimals": 2,
+           "displayName": "",
+           "mappings": [],
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
-               "fill": 1,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "Time"
+             },
+             "properties": [
+               {
+                 "id": "displayName",
+                 "value": "Time"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.align"
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "Value"
+             },
+             "properties": [
+               {
+                 "id": "displayName",
+                 "value": "Uploaded Ago"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "unit",
+                 "value": "s"
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Stream)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows the relative time of last successful upload to the object-store bucket.",
-               "fill": 1,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "decimals",
+                 "value": 2
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Uploaded Ago",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "time() - max by (job, bucket) (thanos_objstore_bucket_last_successful_upload_time{job=~\"$job\"})",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Successful Upload",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.align"
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 24,
+         "x": 0,
+         "y": 17
+       },
+       "id": 7,
+       "options": {
+         "cellHeight": "sm",
+         "footer": {
+           "countRows": false,
+           "fields": "",
+           "reducer": [
+             "sum"
+           ],
+           "show": false
+         },
+         "showHeader": true
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "time() - max by (job, bucket) (thanos_objstore_bucket_last_successful_upload_time{job=~\"$job\"})",
+           "format": "table",
+           "instant": true,
+           "intervalFactor": 2,
+           "legendFormat": "",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Successful Upload",
+       "transformations": [
+         {
+           "id": "merge",
+           "options": {
+             "reducers": []
+           }
+         }
+       ],
+       "type": "table"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 17,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Bucket Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 25
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{operation}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Last Updated",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 25
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{operation}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
                },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 25
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 18,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Resources",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 33
+       },
+       "id": 11,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc all {{instance}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc heap {{instance}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate all {{instance}}",
+           "refId": "C",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate heap {{instance}}",
+           "refId": "D",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse heap {{instance}}",
+           "refId": "E",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse stack {{instance}}",
+           "refId": "F",
+           "step": 10
+         }
+       ],
+       "title": "Memory Used",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 33
+       },
+       "id": 12,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_goroutines{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Goroutines",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bucket Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse stack {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Used",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_gc_duration_seconds{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{quantile}} {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "GC Time Quantiles",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resources",
-         "titleSize": "h6"
-      }
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 33
+       },
+       "id": 13,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_gc_duration_seconds{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}} {{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "GC Time Quantiles",
+       "type": "timeseries"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
          },
-         {
-            "allValue": null,
-            "current": {
-               "text": "all",
-               "value": "$__all"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "job",
-            "multi": false,
-            "name": "job",
-            "options": [ ],
-            "query": "label_values(up{job=~\".*thanos-discovery.*\"}, job)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         }
-      ]
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       },
+       {
+         "current": {
+           "selected": false,
+           "text": "All",
+           "value": "$__all"
+         },
+         "datasource": {
+           "type": "prometheus",
+           "uid": "$datasource"
+         },
+         "definition": "",
+         "hide": 0,
+         "includeAll": true,
+         "label": "job",
+         "multi": false,
+         "name": "job",
+         "options": [],
+         "query": "label_values(up{job=~\".*thanos-discovery.*\"}, job)",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 2,
+         "tagValuesQuery": "",
+         "tagsQuery": "",
+         "type": "query",
+         "useTags": false
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Sidecar",
    "uid": "b19644bfbf0ec1e108027cce268d99f7",
-   "version": 0
-}
+   "version": 14,
+   "weekStart": ""
+ }

--- a/charts/thanos/dashboards/store.json
+++ b/charts/thanos/dashboards/store.json
@@ -1,2853 +1,4357 @@
 {
    "annotations": {
-      "list": [ ]
+     "list": [
+       {
+         "builtIn": 1,
+         "datasource": {
+           "type": "grafana",
+           "uid": "-- Grafana --"
+         },
+         "enable": true,
+         "hide": true,
+         "iconColor": "rgba(0, 211, 255, 1)",
+         "name": "Annotations & Alerts",
+         "type": "dashboard"
+       }
+     ]
    },
    "editable": true,
-   "gnetId": null,
+   "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Unary gRPC requests from queriers.",
-               "fill": 10,
-               "id": 1,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
-               "fill": 10,
-               "id": 2,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
-               "fill": 1,
-               "id": 3,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Unary)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of handled Streamed gRPC requests from queriers.",
-               "fill": 10,
-               "id": 4,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "/Aborted/",
-                     "color": "#EAB839"
-                  },
-                  {
-                     "alias": "/AlreadyExists/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "/FailedPrecondition/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/Unimplemented/",
-                     "color": "#E0B400"
-                  },
-                  {
-                     "alias": "/InvalidArgument/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/NotFound/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/PermissionDenied/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Unauthenticated/",
-                     "color": "#1F60C4"
-                  },
-                  {
-                     "alias": "/Canceled/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DataLoss/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/DeadlineExceeded/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Internal/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OutOfRange/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/ResourceExhausted/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unavailable/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/Unknown/",
-                     "color": "#C4162A"
-                  },
-                  {
-                     "alias": "/OK/",
-                     "color": "#37872D"
-                  },
-                  {
-                     "alias": "error",
-                     "color": "#C4162A"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
-               "fill": 10,
-               "id": 5,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
-               "fill": 1,
-               "id": 6,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "gRPC (Stream)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of execution for operations against the bucket.",
-               "fill": 10,
-               "id": 7,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{operation}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
-               "fill": 10,
-               "id": 8,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$__rate_interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{operation}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
-               "fill": 1,
-               "id": 9,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$__rate_interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99 {{job}}",
-                     "refId": "A",
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_sum{job=~\"$job\"}[$__rate_interval])) * 1  / sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}}",
-                     "refId": "B",
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$__rate_interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50 {{job}}",
-                     "refId": "C",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bucket Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of block loads from the bucket.",
-               "fill": 10,
-               "id": 10,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "block loads",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Block Load Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of block loads from the bucket.",
-               "fill": 10,
-               "id": 11,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_block_load_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Block Load Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows rate of block drops.",
-               "fill": 10,
-               "id": 12,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, operation) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "block drops {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Block Drop Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of block drops.",
-               "fill": 10,
-               "id": 13,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_block_drop_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Block Drop Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Block Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show rate of cache requests.",
-               "fill": 10,
-               "id": 14,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_requests_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{item_type}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows ratio of errors compared to the total number of cache hits.",
-               "fill": 10,
-               "id": 15,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_hits_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{item_type}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Hits",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show rate of added items to cache.",
-               "fill": 10,
-               "id": 16,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_added_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{item_type}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Added",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show rate of evicted items from cache.",
-               "fill": 10,
-               "id": 17,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_evicted_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{job}} {{item_type}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Evicted",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Cache Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows size of chunks that have sent to the bucket.",
-               "fill": 1,
-               "id": 18,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Chunk Size",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Store Sent",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 19,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_blocks_queried{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_series_blocks_queried_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_series_blocks_queried_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_blocks_queried{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Block queried",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show the size of data fetched",
-               "fill": 1,
-               "id": 20,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_data_fetched{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job, data_type) (rate(thanos_bucket_store_series_data_fetched_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job, data_type) (rate(thanos_bucket_store_series_data_fetched_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_data_fetched{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Data Fetched",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Show the size of data touched",
-               "fill": 1,
-               "id": 21,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_data_touched{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job, data_type) (rate(thanos_bucket_store_series_data_touched_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job, data_type) (rate(thanos_bucket_store_series_data_touched_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_data_touched{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50: {{data_type}} / {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Data Touched",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 22,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_result_series{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P99",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "sum by (job) (rate(thanos_bucket_store_series_result_series_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_series_result_series_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "mean {{job}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_result_series{job=~\"$job\"}[$__rate_interval])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "P50",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Result series",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Series Operations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to get all series.",
-               "fill": 1,
-               "id": 23,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Get All",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken to merge series.",
-               "fill": 1,
-               "id": 24,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Merge",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "Shows how long has it taken for a series to wait at the gate.",
-               "fill": 1,
-               "id": 25,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "p99",
-                     "color": "#FA6400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p90",
-                     "color": "#E0B400",
-                     "fill": 1,
-                     "fillGradient": 1
-                  },
-                  {
-                     "alias": "p50",
-                     "color": "#37872D",
-                     "fill": 10,
-                     "fillGradient": 0
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p50 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p90 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "p99 {{job}}",
-                     "logBase": 10,
-                     "max": null,
-                     "min": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Gate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Series Operation Durations",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": true,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 26,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate all {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "alloc rate heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse heap {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  },
-                  {
-                     "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "inuse stack {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Used",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 27,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 28,
-               "legend": {
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_gc_duration_seconds{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{quantile}} {{instance}}",
-                     "legendLink": null,
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "GC Time Quantiles",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Resources",
-         "titleSize": "h6"
-      }
+   "id": 49,
+   "links": [],
+   "panels": [
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 0
+       },
+       "id": 29,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Unary)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Unary gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 1
+       },
+       "id": 1,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 1
+       },
+       "id": 2,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"unary\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"unary\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 1
+       },
+       "id": 3,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"unary\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 8
+       },
+       "id": 30,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "gRPC (Stream)",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of handled Streamed gRPC requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Aborted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#EAB839",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/AlreadyExists/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/FailedPrecondition/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unimplemented/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/InvalidArgument/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/NotFound/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/PermissionDenied/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unauthenticated/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#1F60C4",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Canceled/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DataLoss/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/DeadlineExceeded/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Internal/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OutOfRange/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/ResourceExhausted/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unavailable/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/Unknown/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byRegexp",
+               "options": "/OK/"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#C4162A",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 9
+       },
+       "id": 4,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_method, grpc_code) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{grpc_method}} {{grpc_code}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of handled requests from queriers.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 9
+       },
+       "id": 5,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",job=~\"$job\", grpc_type=\"server_stream\"}[$interval])) / ignoring (grpc_code) group_left() sum by (job) (rate(grpc_server_handled_total{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to handle requests from queriers, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 9
+       },
+       "id": 6,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(grpc_server_handling_seconds_bucket{job=~\"$job\", grpc_type=\"server_stream\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 16
+       },
+       "id": 31,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Bucket Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of execution for operations against the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 17
+       },
+       "id": 7,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{operation}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of executed operations against the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 17
+       },
+       "id": 8,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_failures_total{job=~\"$job\"}[$__rate_interval])) / sum by (job, operation) (rate(thanos_objstore_bucket_operations_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{operation}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to execute operations against the bucket, in quantiles.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 17
+       },
+       "id": 9,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$__rate_interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99 {{job}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_sum{job=~\"$job\"}[$__rate_interval])) * 1  / sum by (job, operation) (rate(thanos_objstore_bucket_operation_duration_seconds_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean {{job}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{job=~\"$job\"}[$__rate_interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50 {{job}}",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Duration",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 24
+       },
+       "id": 32,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Block Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of block loads from the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 0,
+         "y": 25
+       },
+       "id": 10,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "block loads",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Block Load Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of block loads from the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 6,
+         "y": 25
+       },
+       "id": 11,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_block_load_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_loads_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Block Load Errors",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows rate of block drops.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 12,
+         "y": 25
+       },
+       "id": 12,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, operation) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "block drops {{job}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Block Drop Rate",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of block drops.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "percentunit"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "error"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E24D42",
+                   "mode": "fixed"
+                 }
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 18,
+         "y": 25
+       },
+       "id": 13,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_block_drop_failures_total{job=~\"$job\"}[$interval])) / sum by (job) (rate(thanos_bucket_store_block_drops_total{job=~\"$job\"}[$interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "error",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Block Drop Errors",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 32
+       },
+       "id": 33,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Cache Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show rate of cache requests.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 0,
+         "y": 33
+       },
+       "id": 14,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_requests_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{item_type}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Requests",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows ratio of errors compared to the total number of cache hits.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 6,
+         "y": 33
+       },
+       "id": 15,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_hits_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{item_type}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Hits",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show rate of added items to cache.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 12,
+         "y": 33
+       },
+       "id": 16,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_added_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{item_type}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Added",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show rate of evicted items from cache.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 100,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 0,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "normal"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 18,
+         "y": 33
+       },
+       "id": 17,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, item_type) (rate(thanos_store_index_cache_items_evicted_total{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{job}} {{item_type}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Evicted",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 40
+       },
+       "id": 34,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Store Sent",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows size of chunks that have sent to the bucket.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 24,
+         "x": 0,
+         "y": 41
+       },
+       "id": 18,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Chunk Size",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 48
+       },
+       "id": 35,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Series Operations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 0,
+         "y": 49
+       },
+       "id": 19,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_blocks_queried{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_series_blocks_queried_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_series_blocks_queried_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean {{job}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_blocks_queried{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Block queried",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show the size of data fetched",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 6,
+         "y": 49
+       },
+       "id": 20,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_data_fetched{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99: {{data_type}} / {{job}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, data_type) (rate(thanos_bucket_store_series_data_fetched_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job, data_type) (rate(thanos_bucket_store_series_data_fetched_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean: {{data_type}} / {{job}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_data_fetched{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50: {{data_type}} / {{job}}",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Data Fetched",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Show the size of data touched",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 12,
+         "y": 49
+       },
+       "id": 21,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_data_touched{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99: {{data_type}} / {{job}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job, data_type) (rate(thanos_bucket_store_series_data_touched_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job, data_type) (rate(thanos_bucket_store_series_data_touched_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean: {{data_type}} / {{job}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_data_touched{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50: {{data_type}} / {{job}}",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Data Touched",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 6,
+         "x": 18,
+         "y": 49
+       },
+       "id": 22,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (le) (rate(thanos_bucket_store_series_result_series{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P99",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "sum by (job) (rate(thanos_bucket_store_series_result_series_sum{job=~\"$job\"}[$__rate_interval])) / sum by (job) (rate(thanos_bucket_store_series_result_series_count{job=~\"$job\"}[$__rate_interval]))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "mean {{job}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (le) (rate(thanos_bucket_store_series_result_series{job=~\"$job\"}[$__rate_interval])))",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "P50",
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Result series",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 56
+       },
+       "id": 36,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Series Operation Durations",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to get all series.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 57
+       },
+       "id": 23,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Get All",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken to merge series.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 57
+       },
+       "id": 24,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Merge",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "description": "Shows how long has it taken for a series to wait at the gate.",
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "s"
+         },
+         "overrides": [
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p99"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#FA6400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p90"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#E0B400",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 10
+               }
+             ]
+           },
+           {
+             "matcher": {
+               "id": "byName",
+               "options": "p50"
+             },
+             "properties": [
+               {
+                 "id": "color",
+                 "value": {
+                   "fixedColor": "#37872D",
+                   "mode": "fixed"
+                 }
+               },
+               {
+                 "id": "custom.fillOpacity",
+                 "value": 100
+               }
+             ]
+           }
+         ]
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 57
+       },
+       "id": 25,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.50, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p50 {{job}}",
+           "logBase": 10,
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.90, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p90 {{job}}",
+           "logBase": 10,
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "histogram_quantile(0.99, sum by (job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{job=~\"$job\"}[$interval]))) * 1",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "p99 {{job}}",
+           "logBase": 10,
+           "refId": "C",
+           "step": 10
+         }
+       ],
+       "title": "Gate",
+       "type": "timeseries"
+     },
+     {
+       "collapsed": false,
+       "datasource": {
+         "type": "prometheus",
+         "uid": "P5DCFC7561CCDE821"
+       },
+       "gridPos": {
+         "h": 1,
+         "w": 24,
+         "x": 0,
+         "y": 64
+       },
+       "id": 37,
+       "panels": [],
+       "targets": [
+         {
+           "datasource": {
+             "type": "prometheus",
+             "uid": "P5DCFC7561CCDE821"
+           },
+           "refId": "A"
+         }
+       ],
+       "title": "Resources",
+       "type": "row"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "bytes"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 0,
+         "y": 65
+       },
+       "id": 26,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc all {{instance}}",
+           "refId": "A",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_alloc_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc heap {{instance}}",
+           "refId": "B",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate all {{instance}}",
+           "refId": "C",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "rate(go_memstats_heap_alloc_bytes{job=~\"$job\"}[30s])",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "alloc rate heap {{instance}}",
+           "refId": "D",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_stack_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse heap {{instance}}",
+           "refId": "E",
+           "step": 10
+         },
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_memstats_heap_inuse_bytes{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "inuse stack {{instance}}",
+           "refId": "F",
+           "step": 10
+         }
+       ],
+       "title": "Memory Used",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 8,
+         "y": 65
+       },
+       "id": 27,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_goroutines{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "Goroutines",
+       "type": "timeseries"
+     },
+     {
+       "datasource": {
+         "uid": "$datasource"
+       },
+       "fieldConfig": {
+         "defaults": {
+           "color": {
+             "mode": "palette-classic"
+           },
+           "custom": {
+             "axisBorderShow": false,
+             "axisCenteredZero": false,
+             "axisColorMode": "text",
+             "axisLabel": "",
+             "axisPlacement": "auto",
+             "barAlignment": 0,
+             "drawStyle": "line",
+             "fillOpacity": 10,
+             "gradientMode": "none",
+             "hideFrom": {
+               "legend": false,
+               "tooltip": false,
+               "viz": false
+             },
+             "insertNulls": false,
+             "lineInterpolation": "linear",
+             "lineWidth": 1,
+             "pointSize": 5,
+             "scaleDistribution": {
+               "type": "linear"
+             },
+             "showPoints": "never",
+             "spanNulls": false,
+             "stacking": {
+               "group": "A",
+               "mode": "none"
+             },
+             "thresholdsStyle": {
+               "mode": "off"
+             }
+           },
+           "mappings": [],
+           "min": 0,
+           "thresholds": {
+             "mode": "absolute",
+             "steps": [
+               {
+                 "color": "green",
+                 "value": null
+               },
+               {
+                 "color": "red",
+                 "value": 80
+               }
+             ]
+           },
+           "unit": "short"
+         },
+         "overrides": []
+       },
+       "gridPos": {
+         "h": 7,
+         "w": 8,
+         "x": 16,
+         "y": 65
+       },
+       "id": 28,
+       "options": {
+         "legend": {
+           "calcs": [],
+           "displayMode": "list",
+           "placement": "bottom",
+           "showLegend": true
+         },
+         "tooltip": {
+           "mode": "single",
+           "sort": "none"
+         }
+       },
+       "pluginVersion": "10.4.0",
+       "targets": [
+         {
+           "datasource": {
+             "uid": "$datasource"
+           },
+           "expr": "go_gc_duration_seconds{job=~\"$job\"}",
+           "format": "time_series",
+           "intervalFactor": 2,
+           "legendFormat": "{{quantile}} {{instance}}",
+           "refId": "A",
+           "step": 10
+         }
+       ],
+       "title": "GC Time Quantiles",
+       "type": "timeseries"
+     }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
-      "thanos-mixin"
+     "thanos-mixin"
    ],
    "templating": {
-      "list": [
-         {
-            "current": {
-               "text": "default",
-               "value": "default"
-            },
-            "hide": 0,
-            "label": null,
-            "name": "datasource",
-            "options": [ ],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "type": "datasource"
+     "list": [
+       {
+         "current": {
+           "selected": false,
+           "text": "default",
+           "value": "default"
          },
-         {
-            "auto": true,
-            "auto_count": 300,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "hide": 0,
-            "label": "interval",
-            "name": "interval",
-            "query": "5m,10m,30m,1h,6h,12h",
-            "refresh": 2,
-            "type": "interval"
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "type": "datasource"
+       },
+       {
+         "auto": true,
+         "auto_count": 300,
+         "auto_min": "10s",
+         "current": {
+           "selected": false,
+           "text": "5m",
+           "value": "5m"
          },
-         {
-            "allValue": null,
-            "current": {
-               "text": "all",
-               "value": "$__all"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": true,
-            "label": "job",
-            "multi": false,
-            "name": "job",
-            "options": [ ],
-            "query": "label_values(up{job=~\".*thanos-store.*\"}, job)",
-            "refresh": 1,
-            "regex": "",
-            "sort": 2,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         }
-      ]
+         "hide": 0,
+         "label": "interval",
+         "name": "interval",
+         "options": [
+           {
+             "selected": false,
+             "text": "auto",
+             "value": "$__auto_interval_interval"
+           },
+           {
+             "selected": true,
+             "text": "5m",
+             "value": "5m"
+           },
+           {
+             "selected": false,
+             "text": "10m",
+             "value": "10m"
+           },
+           {
+             "selected": false,
+             "text": "30m",
+             "value": "30m"
+           },
+           {
+             "selected": false,
+             "text": "1h",
+             "value": "1h"
+           },
+           {
+             "selected": false,
+             "text": "6h",
+             "value": "6h"
+           },
+           {
+             "selected": false,
+             "text": "12h",
+             "value": "12h"
+           }
+         ],
+         "query": "5m,10m,30m,1h,6h,12h",
+         "refresh": 2,
+         "skipUrlSync": false,
+         "type": "interval"
+       },
+       {
+         "current": {
+           "selected": false,
+           "text": "All",
+           "value": "$__all"
+         },
+         "datasource": {
+           "type": "prometheus",
+           "uid": "$datasource"
+         },
+         "definition": "",
+         "hide": 0,
+         "includeAll": true,
+         "label": "job",
+         "multi": false,
+         "name": "job",
+         "options": [],
+         "query": "label_values(up{job=~\".*thanos-store.*\"}, job)",
+         "refresh": 1,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 2,
+         "tagValuesQuery": "",
+         "tagsQuery": "",
+         "type": "query",
+         "useTags": false
+       }
+     ]
    },
    "time": {
-      "from": "now-1h",
-      "to": "now"
+     "from": "now-1h",
+     "to": "now"
    },
    "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
    },
    "timezone": "UTC",
    "title": "Thanos / Store",
    "uid": "e832e8f26403d95fac0ea1c59837588b",
-   "version": 0
-}
+   "version": 29,
+   "weekStart": ""
+ }


### PR DESCRIPTION
## Description of the changes

This PR fixes the dashboards that relied on AngularJS, which has been deprecated and removed in Grafana v11.0. The necessary updates have been made to ensure these dashboards are fully compatible with the latest version of Grafana, preventing any functionality issues due to the removal of AngularJS support.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
